### PR TITLE
Fix metadata favicon URL

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
 			'Legendaarinen juomapeli uudessa kuosissa. Helppo pelata, vaikea lopettaa. Bileet alkaa nappia painamalla!',
 		type: 'website',
 		url: $page.url.href,
-		image: new URL('/favicon.png', $page.url.origin).href
+		image: ''
 	};
 </script>
 
@@ -36,14 +36,14 @@
 	<meta property="og:type" content={metadata.type} />
 	<meta property="og:title" content={metadata.title} />
 	<meta property="og:description" content={metadata.description} />
-	<meta property="og:image" content={metadata.image} />
+	<!--<meta property="og:image" content={metadata.image} /> -->
 	<meta property="og:url" content={metadata.url} />
 	<meta property="og:site_name" content={metadata.name} />
 
 	<!-- Twitter -->
 	<meta name="twitter:title" content={metadata.title} />
 	<meta name="twitter:description" content={metadata.description} />
-	<meta name="twitter:image" content={metadata.image} />
+	<!-- <meta name="twitter:image" content={metadata.image} /> -->
 </svelte:head>
 
 <slot />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { base } from '$app/paths';
 	import type { Metadata } from '$lib/interfaces/metadata';
 
 	import '@picocss/pico';
@@ -12,7 +13,7 @@
 			'Legendaarinen juomapeli uudessa kuosissa. Helppo pelata, vaikea lopettaa. Bileet alkaa nappia painamalla!',
 		type: 'website',
 		url: $page.url.href,
-		image: ''
+		image: `${base}/favicon.png`
 	};
 </script>
 
@@ -36,14 +37,14 @@
 	<meta property="og:type" content={metadata.type} />
 	<meta property="og:title" content={metadata.title} />
 	<meta property="og:description" content={metadata.description} />
-	<!--<meta property="og:image" content={metadata.image} /> -->
+	<meta property="og:image" content={metadata.image} />
 	<meta property="og:url" content={metadata.url} />
 	<meta property="og:site_name" content={metadata.name} />
 
 	<!-- Twitter -->
 	<meta name="twitter:title" content={metadata.title} />
 	<meta name="twitter:description" content={metadata.description} />
-	<!-- <meta name="twitter:image" content={metadata.image} /> -->
+	<meta name="twitter:image" content={metadata.image} />
 </svelte:head>
 
 <slot />


### PR DESCRIPTION
This pull request includes changes to the `src/routes/+layout.svelte` file to improve the handling of paths and URLs. The most important changes include importing the `base` path from `$app/paths` and updating the image URL to use this `base` path.