### PR TITLE
Initial locale should respect the browsers locale

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { t } from 'svelte-i18n';
+	import { t, locale } from 'svelte-i18n';
 	import { Language } from '$lib/languages/language';
 	import { gameStore } from '$lib/stores/gameStore';
 	import { languageStore } from '$lib/stores/languageStore';
@@ -21,7 +21,7 @@
 	}
 </script>
 
-<select class="language pico-background-azure-500" on:change={changeLanguage}>
+<select class="language pico-background-azure-500" bind:value={$locale} on:change={changeLanguage}>
 	{#each Object.values(Language) as language}
 		<option value={language}>{language}</option>
 	{/each}

--- a/src/lib/languages/load.ts
+++ b/src/lib/languages/load.ts
@@ -3,7 +3,7 @@
  * and interact with the Svelte i18n library.
  */
 
-import { init, register, locale as $locale } from 'svelte-i18n';
+import { init, getLocaleFromNavigator, register, locale as $locale } from 'svelte-i18n';
 import { writable, get } from 'svelte/store';
 import { base } from '$app/paths';
 import { getCardUrl, Language } from '$lib/languages/language';
@@ -45,8 +45,8 @@ export function registerLocales(fetchFn: typeof fetch) {
  * Initializes the Svelte i18n library with a fallback locale and an initial locale.
  */
 init({
-	fallbackLocale: 'fi',
-	initialLocale: 'fi'
+	fallbackLocale: 'en',
+	initialLocale: getLocaleFromNavigator()?.split('-')[0]
 });
 
 /**
@@ -151,7 +151,11 @@ export function getStoredLanguage(): Language {
 	if (storedLanguage) {
 		return storedLanguage as Language;
 	}
-	return Language.FI;
+	// Normalize navigator locale.
+	const detectedLocale = getLocaleFromNavigator()?.split('-')[0] as Language;
+
+	// Ensure detectedLocale is a valid Language, otherwise default to English.
+	return Object.values(Language).includes(detectedLocale) ? detectedLocale : Language.EN;
 }
 
 /**


### PR DESCRIPTION
Setting the initial locale to the browsers locale.

- Setting the `init` function from svelte-18n to use the browsers locale when the website first loads up.
- The `getStoredLanguage` must do the same trick since it's called on startup. It returns the first passing value from these in order:
    - The language user has selected
    - The browsers locale
    - English
- Adding bind to language selector to automatically react if using browsers locale.
- This pull request also changes the default language from Finnish to English (if no fitting browser locale).

Closes #65.

