### PR TITLE
Add top level `unstable-component` to deno fmt for Svelte components

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -14,5 +14,6 @@
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage"
-  }
+  },
+  "unstable": ["fmt-component"]
 }


### PR DESCRIPTION
This allows us format Svelte components without specifying `--unstable-component` everytime.