### PR TITLE
Add Umami analytics

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -30,6 +30,8 @@ Select your card quantity and mix the cocktail with tags.
 Switch dynamically between English or Finnish - regret knows no borders
 - 📲 **Add to Home Screen (PWA)**  
 Because bookmarks are for sober people
+- 📊 **Privacy-Respecting Analytics**  
+We count shots taken (metaphorically) without checking IDs. [View our public dashboard](https://cloud.umami.is/share/CrXiQx0T4O8Xjxy1/kalja.xyz)
 
 
 ## 🛠️ Building

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,11 @@
 	<head>
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<link rel="manifest" href="%sveltekit.assets%/manifest.json">
+		<script
+			defer
+			src="https://analytics.kalja.xyz/script.js"
+			data-website-id="1641d04f-a10b-4097-8d85-8b9e38f1d108"
+		></script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/stores/gameStore.ts
+++ b/src/lib/stores/gameStore.ts
@@ -3,6 +3,7 @@ import { ApplicationState } from '$lib/constants/applicationState';
 import type { GameState } from '$lib/interfaces/gameState';
 import { languageStore } from '$lib/stores/languageStore';
 import { Tag } from '$lib/constants/tag';
+import * as analytics from '$lib/utils/analytics';
 import { createNewGame } from '$lib/gameState/createNewGame';
 import { loadGameState, saveGameState } from '$lib/gameState/gameStateStorage';
 import { loadCards, loadSingleCard } from '$lib/cards/cardStorage';
@@ -96,6 +97,9 @@ function createGameStore() {
 					state.cards = cards;
 					const updatedState = startGame(state);
 					saveGameState(updatedState);
+					analytics.trackEvent('players', {
+						players: updatedState.players.length,
+					});
 					return updatedState;
 				});
 			}

--- a/src/lib/utils/analytics.ts
+++ b/src/lib/utils/analytics.ts
@@ -1,0 +1,34 @@
+/**
+ * Analytics utility for tracking events with Umami.
+ */
+
+interface UmamiTracker {
+	track: (eventName: string, eventData?: Record<string, unknown>) => void;
+}
+
+declare global {
+	interface Window {
+		umami?: UmamiTracker;
+	}
+}
+
+/**
+ * Track a custom event with Umami Analytics.
+ *
+ * @param eventName - The name of the event to track
+ * @param eventData - Optional data to attach to the event
+ *
+ * @example
+ * trackEvent('game-started', { players: 4 });
+ */
+export function trackEvent(eventName: string, eventData?: Record<string, unknown>): void {
+	// Check whether Umami is loaded or not
+	if (typeof globalThis.window !== 'undefined' && globalThis.window.umami) {
+		try {
+			globalThis.window.umami.track(eventName, eventData);
+		} catch (error) {
+			// Silently fail
+			console.warn('Failed to track event:', eventName, error);
+		}
+	}
+}


### PR DESCRIPTION
This PR adds Umami as an anonymous analytics platform to track usage statistics. To ensure reliable data collection even when users have adblockers, I've set up a Cloudflare Worker that proxies requests to Umami Cloud. This bypasses common blocklists.

I also added a new `analytics.ts` utility module to handle all tracking in a cleaner way, avoiding messy direct window context access throughout the codebase. The first custom event now tracks how many players are in the lobby when a game starts, giving us insights into typical game sizes.