### PR TITLE
Updating dependencies

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2,22 +2,22 @@
   "version": "5",
   "specifiers": {
     "npm:@picocss/pico@^2.1.1": "2.1.1",
-    "npm:@sveltejs/adapter-static@^3.0.10": "3.0.10_@sveltejs+kit@2.57.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.4___vite@7.3.2____@types+node@20.19.23___@types+node@20.19.23__svelte@5.55.4__typescript@5.9.3__vite@7.3.2___@types+node@20.19.23__@types+node@20.19.23_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.4__vite@7.3.2___@types+node@20.19.23__@types+node@20.19.23_@types+node@20.19.23_svelte@5.55.4_typescript@5.9.3_vite@7.3.2__@types+node@20.19.23",
-    "npm:@sveltejs/kit@^2.57.1": "2.57.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.4__vite@7.3.2___@types+node@20.19.23__@types+node@20.19.23_svelte@5.55.4_typescript@5.9.3_vite@7.3.2__@types+node@20.19.23_@types+node@20.19.23",
-    "npm:@sveltejs/vite-plugin-svelte@^6.2.4": "6.2.4_svelte@5.55.4_vite@7.3.2__@types+node@20.19.23_@types+node@20.19.23",
-    "npm:@testing-library/svelte@^5.3.1": "5.3.1_svelte@5.55.4_vite@7.3.2__@types+node@20.19.23_vitest@3.2.4__@types+node@20.19.23__happy-dom@20.9.0_@types+node@20.19.23_happy-dom@20.9.0",
+    "npm:@sveltejs/adapter-static@^3.0.10": "3.0.10_@sveltejs+kit@2.65.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.56.3___vite@7.3.5____@types+node@20.19.23___@types+node@20.19.23__svelte@5.56.3__typescript@5.9.3__vite@7.3.5___@types+node@20.19.23__@types+node@20.19.23_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.56.3__vite@7.3.5___@types+node@20.19.23__@types+node@20.19.23_@types+node@20.19.23_svelte@5.56.3_typescript@5.9.3_vite@7.3.5__@types+node@20.19.23",
+    "npm:@sveltejs/kit@^2.65.1": "2.65.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.56.3__vite@7.3.5___@types+node@20.19.23__@types+node@20.19.23_svelte@5.56.3_typescript@5.9.3_vite@7.3.5__@types+node@20.19.23_@types+node@20.19.23",
+    "npm:@sveltejs/vite-plugin-svelte@^6.2.4": "6.2.4_svelte@5.56.3_vite@7.3.5__@types+node@20.19.23_@types+node@20.19.23",
+    "npm:@testing-library/svelte@^5.3.1": "5.3.1_svelte@5.56.3_vite@7.3.5__@types+node@20.19.23_vitest@3.2.6__@types+node@20.19.23__happy-dom@20.10.3_@types+node@20.19.23_happy-dom@20.10.3",
     "npm:@types/node@*": "20.19.23",
-    "npm:@vitest/coverage-v8@^3.2.4": "3.2.4_vitest@3.2.4__@types+node@20.19.23__happy-dom@20.9.0_happy-dom@20.9.0",
-    "npm:happy-dom@^20.9.0": "20.9.0",
-    "npm:prettier-plugin-svelte@^3.5.1": "3.5.1_prettier@3.8.3_svelte@5.55.4",
-    "npm:prettier@^3.8.3": "3.8.3",
-    "npm:svelte-check@^4.4.6": "4.4.6_svelte@5.55.4_typescript@5.9.3",
-    "npm:svelte-i18n@^4.0.1": "4.0.1_svelte@5.55.4",
-    "npm:svelte@^5.55.4": "5.55.4",
+    "npm:@vitest/coverage-v8@^3.2.6": "3.2.6_vitest@3.2.6__@types+node@20.19.23__happy-dom@20.10.3_@types+node@20.19.23_happy-dom@20.10.3",
+    "npm:happy-dom@^20.10.3": "20.10.3",
+    "npm:prettier-plugin-svelte@^3.5.2": "3.5.2_prettier@3.8.4_svelte@5.56.3",
+    "npm:prettier@^3.8.4": "3.8.4",
+    "npm:svelte-check@^4.6.0": "4.6.0_svelte@5.56.3_typescript@5.9.3",
+    "npm:svelte-i18n@^4.0.1": "4.0.1_svelte@5.56.3",
+    "npm:svelte@^5.56.3": "5.56.3",
     "npm:tslib@^2.8.1": "2.8.1",
     "npm:typescript@^5.9.3": "5.9.3",
-    "npm:vite@^7.3.2": "7.3.2_@types+node@20.19.23",
-    "npm:vitest@^3.2.4": "3.2.4_@types+node@20.19.23_happy-dom@20.9.0"
+    "npm:vite@^7.3.5": "7.3.5_@types+node@20.19.23",
+    "npm:vitest@^3.2.6": "3.2.6_@types+node@20.19.23_happy-dom@20.10.3"
   },
   "npm": {
     "@ampproject/remapping@2.3.0": {
@@ -35,14 +35,14 @@
         "picocolors"
       ]
     },
-    "@babel/helper-string-parser@7.27.1": {
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
+    "@babel/helper-string-parser@7.29.7": {
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="
     },
-    "@babel/helper-validator-identifier@7.28.5": {
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
+    "@babel/helper-validator-identifier@7.29.7": {
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="
     },
-    "@babel/parser@7.28.4": {
-      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+    "@babel/parser@7.29.7": {
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dependencies": [
         "@babel/types"
       ],
@@ -51,8 +51,8 @@
     "@babel/runtime@7.28.6": {
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="
     },
-    "@babel/types@7.28.4": {
-      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+    "@babel/types@7.29.7": {
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dependencies": [
         "@babel/helper-string-parser",
         "@babel/helper-validator-identifier"
@@ -347,14 +347,14 @@
       "dependencies": [
         "string-width@5.1.2",
         "string-width-cjs@npm:string-width@4.2.3",
-        "strip-ansi@7.1.2",
+        "strip-ansi@7.2.0",
         "strip-ansi-cjs@npm:strip-ansi@6.0.1",
         "wrap-ansi@8.1.0",
         "wrap-ansi-cjs@npm:wrap-ansi@7.0.0"
       ]
     },
-    "@istanbuljs/schema@0.1.3": {
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="
+    "@istanbuljs/schema@0.1.6": {
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw=="
     },
     "@jridgewell/gen-mapping@0.3.13": {
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
@@ -505,20 +505,20 @@
     "@standard-schema/spec@1.0.0": {
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
     },
-    "@sveltejs/acorn-typescript@1.0.6_acorn@8.16.0": {
-      "integrity": "sha512-4awhxtMh4cx9blePWl10HRHj8Iivtqj+2QdDCSMDzxG+XKa9+VCNupQuCuvzEhYPzZSrX+0gC+0lHA/0fFKKQQ==",
+    "@sveltejs/acorn-typescript@1.0.10_acorn@8.17.0": {
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
       "dependencies": [
         "acorn"
       ]
     },
-    "@sveltejs/adapter-static@3.0.10_@sveltejs+kit@2.57.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.4___vite@7.3.2____@types+node@20.19.23___@types+node@20.19.23__svelte@5.55.4__typescript@5.9.3__vite@7.3.2___@types+node@20.19.23__@types+node@20.19.23_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.4__vite@7.3.2___@types+node@20.19.23__@types+node@20.19.23_@types+node@20.19.23_svelte@5.55.4_typescript@5.9.3_vite@7.3.2__@types+node@20.19.23": {
+    "@sveltejs/adapter-static@3.0.10_@sveltejs+kit@2.65.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.56.3___vite@7.3.5____@types+node@20.19.23___@types+node@20.19.23__svelte@5.56.3__typescript@5.9.3__vite@7.3.5___@types+node@20.19.23__@types+node@20.19.23_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.56.3__vite@7.3.5___@types+node@20.19.23__@types+node@20.19.23_@types+node@20.19.23_svelte@5.56.3_typescript@5.9.3_vite@7.3.5__@types+node@20.19.23": {
       "integrity": "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==",
       "dependencies": [
         "@sveltejs/kit"
       ]
     },
-    "@sveltejs/kit@2.57.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.4__vite@7.3.2___@types+node@20.19.23__@types+node@20.19.23_svelte@5.55.4_typescript@5.9.3_vite@7.3.2__@types+node@20.19.23_@types+node@20.19.23": {
-      "integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
+    "@sveltejs/kit@2.65.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.56.3__vite@7.3.5___@types+node@20.19.23__@types+node@20.19.23_svelte@5.56.3_typescript@5.9.3_vite@7.3.5__@types+node@20.19.23_@types+node@20.19.23": {
+      "integrity": "sha512-Sa1rFYYqBB+zv3rIxAg/CsFskR/x4aj5BY/hvLxBd9r/mqbipxM945As1K3PqsDicJAyekPR0BlWoVIiw2OHYg==",
       "dependencies": [
         "@standard-schema/spec",
         "@sveltejs/acorn-typescript",
@@ -542,7 +542,10 @@
       ],
       "bin": true
     },
-    "@sveltejs/vite-plugin-svelte-inspector@5.0.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.4__vite@7.3.2___@types+node@20.19.23__@types+node@20.19.23_svelte@5.55.4_vite@7.3.2__@types+node@20.19.23_@types+node@20.19.23": {
+    "@sveltejs/load-config@0.1.1": {
+      "integrity": "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA=="
+    },
+    "@sveltejs/vite-plugin-svelte-inspector@5.0.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.56.3__vite@7.3.5___@types+node@20.19.23__@types+node@20.19.23_svelte@5.56.3_vite@7.3.5__@types+node@20.19.23_@types+node@20.19.23": {
       "integrity": "sha512-ubWshlMk4bc8mkwWbg6vNvCeT7lGQojE3ijDh3QTR6Zr/R+GXxsGbyH4PExEPpiFmqPhYiVSVmHBjUcVc1JIrA==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte",
@@ -551,7 +554,7 @@
         "vite"
       ]
     },
-    "@sveltejs/vite-plugin-svelte@6.2.4_svelte@5.55.4_vite@7.3.2__@types+node@20.19.23_@types+node@20.19.23": {
+    "@sveltejs/vite-plugin-svelte@6.2.4_svelte@5.56.3_vite@7.3.5__@types+node@20.19.23_@types+node@20.19.23": {
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte-inspector",
@@ -576,13 +579,13 @@
         "pretty-format"
       ]
     },
-    "@testing-library/svelte-core@1.0.0_svelte@5.55.4": {
+    "@testing-library/svelte-core@1.0.0_svelte@5.56.3": {
       "integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
       "dependencies": [
         "svelte"
       ]
     },
-    "@testing-library/svelte@5.3.1_svelte@5.55.4_vite@7.3.2__@types+node@20.19.23_vitest@3.2.4__@types+node@20.19.23__happy-dom@20.9.0_@types+node@20.19.23_happy-dom@20.9.0": {
+    "@testing-library/svelte@5.3.1_svelte@5.56.3_vite@7.3.5__@types+node@20.19.23_vitest@3.2.6__@types+node@20.19.23__happy-dom@20.10.3_@types+node@20.19.23_happy-dom@20.10.3": {
       "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
       "dependencies": [
         "@testing-library/dom",
@@ -633,11 +636,8 @@
         "@types/node"
       ]
     },
-    "@typescript-eslint/types@8.57.0": {
-      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg=="
-    },
-    "@vitest/coverage-v8@3.2.4_vitest@3.2.4__@types+node@20.19.23__happy-dom@20.9.0_happy-dom@20.9.0": {
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+    "@vitest/coverage-v8@3.2.6_vitest@3.2.6__@types+node@20.19.23__happy-dom@20.10.3_@types+node@20.19.23_happy-dom@20.10.3": {
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
       "dependencies": [
         "@ampproject/remapping",
         "@bcoe/v8-coverage",
@@ -655,8 +655,8 @@
         "vitest"
       ]
     },
-    "@vitest/expect@3.2.4": {
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+    "@vitest/expect@3.2.6": {
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dependencies": [
         "@types/chai",
         "@vitest/spy",
@@ -665,8 +665,8 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@3.2.4_vite@7.3.2__@types+node@20.19.23_@types+node@20.19.23": {
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+    "@vitest/mocker@3.2.6_vite@7.3.5__@types+node@20.19.23_@types+node@20.19.23": {
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dependencies": [
         "@vitest/spy",
         "estree-walker@3.0.3",
@@ -677,44 +677,44 @@
         "vite"
       ]
     },
-    "@vitest/pretty-format@3.2.4": {
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+    "@vitest/pretty-format@3.2.6": {
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dependencies": [
         "tinyrainbow"
       ]
     },
-    "@vitest/runner@3.2.4": {
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+    "@vitest/runner@3.2.6": {
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dependencies": [
         "@vitest/utils",
         "pathe",
         "strip-literal"
       ]
     },
-    "@vitest/snapshot@3.2.4": {
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+    "@vitest/snapshot@3.2.6": {
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dependencies": [
         "@vitest/pretty-format",
         "magic-string",
         "pathe"
       ]
     },
-    "@vitest/spy@3.2.4": {
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+    "@vitest/spy@3.2.6": {
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dependencies": [
         "tinyspy"
       ]
     },
-    "@vitest/utils@3.2.4": {
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+    "@vitest/utils@3.2.6": {
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dependencies": [
         "@vitest/pretty-format",
         "loupe",
         "tinyrainbow"
       ]
     },
-    "acorn@8.16.0": {
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+    "acorn@8.17.0": {
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "bin": true
     },
     "ansi-regex@5.0.1": {
@@ -747,12 +747,12 @@
     "assertion-error@2.0.1": {
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="
     },
-    "ast-v8-to-istanbul@0.3.7": {
-      "integrity": "sha512-kr1Hy6YRZBkGQSb6puP+D6FQ59Cx4m0siYhAxygMCAgadiWQ6oxAxQXHOMvJx67SJ63jRoVIIg5eXzUbbct1ww==",
+    "ast-v8-to-istanbul@0.3.12": {
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
       "dependencies": [
         "@jridgewell/trace-mapping",
         "estree-walker@3.0.3",
-        "js-tokens@9.0.1"
+        "js-tokens@10.0.0"
       ]
     },
     "axobject-query@4.1.0": {
@@ -761,10 +761,25 @@
     "balanced-match@1.0.2": {
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "brace-expansion@2.0.2": {
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+    "balanced-match@4.0.4": {
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+    },
+    "brace-expansion@2.1.1": {
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dependencies": [
-        "balanced-match"
+        "balanced-match@1.0.2"
+      ]
+    },
+    "brace-expansion@5.0.6": {
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dependencies": [
+        "balanced-match@4.0.4"
+      ]
+    },
+    "buffer-image-size@0.6.4": {
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dependencies": [
+        "@types/node"
       ]
     },
     "cac@6.7.14": {
@@ -847,8 +862,8 @@
     "dequal@2.0.3": {
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
-    "devalue@5.6.4": {
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA=="
+    "devalue@5.8.1": {
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="
     },
     "dom-accessibility-api@0.5.16": {
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="
@@ -977,11 +992,10 @@
         "type"
       ]
     },
-    "esrap@2.2.4": {
-      "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+    "esrap@2.2.11": {
+      "integrity": "sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==",
       "dependencies": [
-        "@jridgewell/sourcemap-codec",
-        "@typescript-eslint/types"
+        "@jridgewell/sourcemap-codec"
       ]
     },
     "estree-walker@2.0.2": {
@@ -1030,12 +1044,12 @@
       "os": ["darwin"],
       "scripts": true
     },
-    "glob@10.4.5": {
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+    "glob@10.5.0": {
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dependencies": [
         "foreground-child",
         "jackspeak",
-        "minimatch",
+        "minimatch@9.0.9",
         "minipass",
         "package-json-from-dist",
         "path-scurry"
@@ -1049,12 +1063,13 @@
     "globrex@0.1.2": {
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
-    "happy-dom@20.9.0": {
-      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+    "happy-dom@20.10.3": {
+      "integrity": "sha512-Hjdiy8RziuCcn5z04QI/rlsNuQoG8P0xxjgvsSMpi89cvIXIOcucQtiHS1yHSShxoBcSCeYqAskINmTiy/mlfw==",
       "dependencies": [
         "@types/node",
         "@types/whatwg-mimetype",
         "@types/ws",
+        "buffer-image-size",
         "entities",
         "whatwg-mimetype",
         "ws"
@@ -1125,6 +1140,9 @@
         "@pkgjs/parseargs"
       ]
     },
+    "js-tokens@10.0.0": {
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="
+    },
     "js-tokens@4.0.0": {
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
@@ -1186,14 +1204,20 @@
         "timers-ext"
       ]
     },
-    "minimatch@9.0.5": {
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+    "minimatch@10.2.5": {
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dependencies": [
-        "brace-expansion"
+        "brace-expansion@5.0.6"
       ]
     },
-    "minipass@7.1.2": {
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
+    "minimatch@9.0.9": {
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dependencies": [
+        "brace-expansion@2.1.1"
+      ]
+    },
+    "minipass@7.1.3": {
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
     },
     "mri@1.2.0": {
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
@@ -1247,15 +1271,15 @@
         "source-map-js"
       ]
     },
-    "prettier-plugin-svelte@3.5.1_prettier@3.8.3_svelte@5.55.4": {
-      "integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
+    "prettier-plugin-svelte@3.5.2_prettier@3.8.4_svelte@5.56.3": {
+      "integrity": "sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==",
       "dependencies": [
         "prettier",
         "svelte"
       ]
     },
-    "prettier@3.8.3": {
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+    "prettier@3.8.4": {
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "bin": true
     },
     "pretty-format@27.5.1": {
@@ -1310,8 +1334,8 @@
         "mri"
       ]
     },
-    "semver@7.7.3": {
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+    "semver@7.8.4": {
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "bin": true
     },
     "set-cookie-parser@3.0.1": {
@@ -1362,7 +1386,7 @@
       "dependencies": [
         "eastasianwidth",
         "emoji-regex@9.2.2",
-        "strip-ansi@7.1.2"
+        "strip-ansi@7.2.0"
       ]
     },
     "strip-ansi@6.0.1": {
@@ -1371,8 +1395,8 @@
         "ansi-regex@5.0.1"
       ]
     },
-    "strip-ansi@7.1.2": {
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+    "strip-ansi@7.2.0": {
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dependencies": [
         "ansi-regex@6.2.2"
       ]
@@ -1389,10 +1413,11 @@
         "has-flag"
       ]
     },
-    "svelte-check@4.4.6_svelte@5.55.4_typescript@5.9.3": {
-      "integrity": "sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==",
+    "svelte-check@4.6.0_svelte@5.56.3_typescript@5.9.3": {
+      "integrity": "sha512-KhVnDFDSid57mmZtHz8gfW8AAGylOZ0vPnOIzVmAL+urzwK8sBYXRss953gD8T0OdgAQ11mdWhE6uadmtOz8TQ==",
       "dependencies": [
         "@jridgewell/trace-mapping",
+        "@sveltejs/load-config",
         "chokidar",
         "fdir",
         "picocolors",
@@ -1402,7 +1427,7 @@
       ],
       "bin": true
     },
-    "svelte-i18n@4.0.1_svelte@5.55.4": {
+    "svelte-i18n@4.0.1_svelte@5.56.3": {
       "integrity": "sha512-jaykGlGT5PUaaq04JWbJREvivlCnALtT+m87Kbm0fxyYHynkQaxQMnIKHLm2WeIuBRoljzwgyvz0Z6/CMwfdmQ==",
       "dependencies": [
         "cli-color",
@@ -1416,8 +1441,8 @@
       ],
       "bin": true
     },
-    "svelte@5.55.4": {
-      "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
+    "svelte@5.56.3": {
+      "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
       "dependencies": [
         "@jridgewell/remapping",
         "@jridgewell/sourcemap-codec",
@@ -1437,12 +1462,12 @@
         "zimmerframe"
       ]
     },
-    "test-exclude@7.0.1": {
-      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+    "test-exclude@7.0.2": {
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
       "dependencies": [
         "@istanbuljs/schema",
         "glob",
-        "minimatch"
+        "minimatch@10.2.5"
       ]
     },
     "timers-ext@0.1.8": {
@@ -1508,8 +1533,8 @@
       ],
       "bin": true
     },
-    "vite@7.3.2_@types+node@20.19.23": {
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+    "vite@7.3.5_@types+node@20.19.23": {
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dependencies": [
         "@types/node",
         "esbuild@0.27.4",
@@ -1527,7 +1552,7 @@
       ],
       "bin": true
     },
-    "vitefu@1.1.1_vite@7.3.2__@types+node@20.19.23_@types+node@20.19.23": {
+    "vitefu@1.1.1_vite@7.3.5__@types+node@20.19.23_@types+node@20.19.23": {
       "integrity": "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==",
       "dependencies": [
         "vite"
@@ -1536,8 +1561,8 @@
         "vite"
       ]
     },
-    "vitest@3.2.4_@types+node@20.19.23_happy-dom@20.9.0": {
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+    "vitest@3.2.6_@types+node@20.19.23_happy-dom@20.10.3": {
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dependencies": [
         "@types/chai",
         "@types/node",
@@ -1602,11 +1627,11 @@
       "dependencies": [
         "ansi-styles@6.2.3",
         "string-width@5.1.2",
-        "strip-ansi@7.1.2"
+        "strip-ansi@7.2.0"
       ]
     },
-    "ws@8.19.0": {
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="
+    "ws@8.21.0": {
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="
     },
     "zimmerframe@1.1.4": {
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="
@@ -1743,20 +1768,20 @@
       "dependencies": [
         "npm:@picocss/pico@^2.1.1",
         "npm:@sveltejs/adapter-static@^3.0.10",
-        "npm:@sveltejs/kit@^2.57.1",
+        "npm:@sveltejs/kit@^2.65.1",
         "npm:@sveltejs/vite-plugin-svelte@^6.2.4",
         "npm:@testing-library/svelte@^5.3.1",
-        "npm:@vitest/coverage-v8@^3.2.4",
-        "npm:happy-dom@^20.9.0",
-        "npm:prettier-plugin-svelte@^3.5.1",
-        "npm:prettier@^3.8.3",
-        "npm:svelte-check@^4.4.6",
+        "npm:@vitest/coverage-v8@^3.2.6",
+        "npm:happy-dom@^20.10.3",
+        "npm:prettier-plugin-svelte@^3.5.2",
+        "npm:prettier@^3.8.4",
+        "npm:svelte-check@^4.6.0",
         "npm:svelte-i18n@^4.0.1",
-        "npm:svelte@^5.55.4",
+        "npm:svelte@^5.56.3",
         "npm:tslib@^2.8.1",
         "npm:typescript@^5.9.3",
-        "npm:vite@^7.3.2",
-        "npm:vitest@^3.2.4"
+        "npm:vite@^7.3.5",
+        "npm:vitest@^3.2.6"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,19 +16,19 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@sveltejs/kit": "^2.57.1",
+		"@sveltejs/kit": "^2.65.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@testing-library/svelte": "^5.3.1",
-		"happy-dom": "^20.9.0",
-		"@vitest/coverage-v8": "^3.2.4",
-		"prettier": "^3.8.3",
-		"prettier-plugin-svelte": "^3.5.1",
-		"svelte": "^5.55.4",
-		"svelte-check": "^4.4.6",
+		"happy-dom": "^20.10.3",
+		"@vitest/coverage-v8": "^3.2.6",
+		"prettier": "^3.8.4",
+		"prettier-plugin-svelte": "^3.5.2",
+		"svelte": "^5.56.3",
+		"svelte-check": "^4.6.0",
 		"tslib": "^2.8.1",
 		"typescript": "^5.9.3",
-		"vite": "^7.3.2",
-		"vitest": "^3.2.4"
+		"vite": "^7.3.5",
+		"vitest": "^3.2.6"
 	},
 	"type": "module",
 	"dependencies": {


### PR DESCRIPTION
Updating following dependencies: 
 - npm:@sveltejs/kit          ^2.57.1 ->  ^2.65.1
 - npm:@vitest/coverage-v8     ^3.2.4 ->   ^3.2.6
 - npm:happy-dom              ^20.9.0 -> ^20.10.3
 - npm:prettier                ^3.8.3 ->   ^3.8.4
 - npm:prettier-plugin-svelte  ^3.5.1 ->   ^3.5.2
 - npm:svelte                 ^5.55.4 ->  ^5.56.3
 - npm:svelte-check            ^4.4.6 ->   ^4.6.0
 - npm:vite                    ^7.3.2 ->   ^7.3.5
 - npm:vitest                  ^3.2.4 ->   ^3.2.6